### PR TITLE
Added passing test on nested log and exp expressions

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -95,7 +95,10 @@ describe("Parsing tests", () => {
     var result = evaluateExpression("2^2^2");
     expect(result).toBe("16");
   })
-  
+  test('test simple expression log(3^2 + ln(8^exp(2))/3.333)', () => {
+    var result = evaluateExpression("log(3^2 + ln(8^exp(2))/3.333)");
+    expect(result).toBe("2.610804380306326");
+  })
 
   
  })


### PR DESCRIPTION
Added passing test that was not present previously using nested log, exp and ln statements.
Test did not pass previously until changes introduced in dev-f-test-logexp-with-additional-operators