### PR TITLE
Dev f test logexp with additional operators

### DIFF
--- a/controllers/evaluate_expression.js
+++ b/controllers/evaluate_expression.js
@@ -61,7 +61,8 @@ function buildInfix(expression) {
            expression.charAt(i) == ')' ||       //R brackets
            expression.charAt(i) == '^')         //power
         {
-            infix.push(number);
+            if(number != "")
+                infix.push(number);
             number = "";
             infix.push("" + expression.charAt(i));
         }
@@ -73,7 +74,8 @@ function buildInfix(expression) {
                 expression.charAt(i+2) == 'g')
         {
             i += 2
-            infix.push(number);
+            if(number != "")
+                infix.push(number);
             number = "";
             infix.push("log");
         }
@@ -82,7 +84,8 @@ function buildInfix(expression) {
                 expression.charAt(i+2) == 'p')
         {
             i += 2
-            infix.push(number);
+            if(number != "")
+                infix.push(number);
             number = "";
             infix.push("exp");
         }
@@ -92,7 +95,8 @@ function buildInfix(expression) {
             expression.charAt(i+1) == 'n')
         {
             i += 1
-            infix.push(number);
+            if(number != "")
+                infix.push(number);
             number = "";
             infix.push("ln");
         }
@@ -105,7 +109,8 @@ function buildInfix(expression) {
     }//end of for loop through expression
 
     //at end of string, should have unpushed number left over (no operator was encountered to push it), so push that
-    infix.push(number);
+    if(number != "")
+        infix.push(number);
     //return expression as infix array
     return infix;
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -95,6 +95,15 @@ describe("Parsing tests", () => {
     var result = evaluateExpression("2^2^2");
     expect(result).toBe("16");
   })
+
+  test('test simple expression 2.4 + exp(2)', () => {
+    var result = evaluateExpression("2.4 + exp(2)");
+    expect(result).toBe("9.78905609893065");
+  })
+  test('test simple expression 1.5 + log(3)', () => {
+    var result = evaluateExpression("2.4 + exp(2)");
+    expect(result).toBe("2.5986122886681096");
+  })
   
 
   


### PR DESCRIPTION
Tests have been added, and buildInfix() altered to allow the tests to pass.
Bug with log/exp put after a different operator introducing empty strings into built infix and postfix arrays has been resolved

Unlike previous pull request, this is attempting to merge with dev branch instead of main. Apologies for previous mistake.